### PR TITLE
ref #2 updated edit and delete buttons hover title

### DIFF
--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -40,14 +40,14 @@ function showCat({ cat, onEdit, handleOpenDeleteDialog }) {
 
       <TableCell>
         <IconButton
-          title="editButton"
+          title="Edit"
           onClick={() => onEdit(cat)}
           color="primary"
         >
           <EditIcon />
         </IconButton>
         <IconButton
-          title="deleteButton"
+          title="Delete"
           onClick={() => handleOpenDeleteDialog(cat.id)}
           color="secondary"
         >


### PR DESCRIPTION
Changed the following hover titles:
- `editIcon` to `Edit` and,
-  `deleteIcon` to `Delete`
